### PR TITLE
Add service carousels and cards to Explore page

### DIFF
--- a/frontend/src/components/explore/ServiceCard.jsx
+++ b/frontend/src/components/explore/ServiceCard.jsx
@@ -1,0 +1,59 @@
+// src/components/explore/ServiceCard.jsx
+import React from "react";
+
+const pocketbaseUrl = import.meta.env.VITE_POCKETBASE_URL;
+
+// Función para generar URL de imagen desde PocketBase
+function getImageUrl(service) {
+    if (!service?.logo) return null;
+    return `${pocketbaseUrl}/api/files/services/${service.id}/${service.logo}`;
+}
+
+export default function ServiceCard({ service }) {
+    const imageUrl = getImageUrl(service);
+    const originalPrice = service.price || 0;
+    const discount = service.discount || 0;
+    const hasDiscount = discount > 0;
+    const discountedPrice = hasDiscount
+        ? Math.round(originalPrice * (1 - discount / 100))
+        : originalPrice;
+
+    return (
+      <div className="w-full max-w-lg h-auto md:h-48 bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-200 flex flex-col md:flex-row gap-4 md:gap-6">
+        {/* LA PUTA FOTO */}
+        <div className="md:basis-2/5 h-32 md:h-full flex items-center justify-center overflow-hidden rounded-xl">
+          {imageUrl ? (
+            <img
+              src={imageUrl}
+              alt={service.title}
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <span className="text-gray-500">Sin imagen disponible</span>
+          )}
+        </div>
+        {/* LAS DEMAS ESTUPIDECES */}
+        <div className="md:basis-3/5 flex-1 h-full flex flex-col justify-center px-4 py-3 md:px-6 md:py-4">
+          <h2 className="text-base md:text-xl font-bold text-gray-900 mb-1">{service.title}</h2>
+          <div className="text-gray-700 text-sm md:text-base mb-2">{service.business}</div>
+          <div className="flex items-center gap-2 mb-0">
+            <span className="text-base md:text-lg font-semibold text-gray-900">
+              GTQ {discountedPrice}
+            </span>
+            {hasDiscount && (
+              <>
+                <span className="text-gray-400 line-through text-sm md:text-base">
+                  GTQ {originalPrice}
+                </span>
+              </>
+            )}
+          </div>
+          {hasDiscount && (
+            <span className="bg-indigo-700 text-white text-xs font-semibold px-2 py-1 rounded mt-2 w-fit self-end">
+              {discount}% descuento
+            </span>
+          )}
+        </div>
+      </div>
+    );
+}

--- a/frontend/src/components/explore/ServicesCarousel.jsx
+++ b/frontend/src/components/explore/ServicesCarousel.jsx
@@ -1,0 +1,79 @@
+// src/components/explore/ServicesCarousel.jsx
+import React, { useRef } from "react";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import ServiceCard from "./ServiceCard";
+
+export default function ServicesCarousel({ 
+    title, 
+    services = [], 
+    loading = false 
+}) {
+    const scrollRef = useRef(null);
+
+    const scrollBy = (direction) => {
+        if (!scrollRef.current) return;
+        const scrollAmount = 340; // Ajusta según el ancho de tu tarjeta
+        scrollRef.current.scrollBy({
+            left: direction === "left" ? -scrollAmount : scrollAmount,
+            behavior: "smooth",
+        });
+    };
+
+    if (loading) {
+        return (
+            <div className="w-full">
+                <h2 className="text-xl font-bold text-gray-900 mb-4">{title}</h2>
+                <div className="flex gap-4 overflow-hidden">
+                    {[...Array(4)].map((_, index) => (
+                        <div key={index} className="min-w-[320px] h-32 bg-gray-200 rounded-xl animate-pulse"></div>
+                    ))}
+                </div>
+            </div>
+        );
+    }
+
+    if (!services.length) {
+        return (
+            <div className="w-full">
+                <h2 className="text-xl font-bold text-gray-900 mb-4">{title}</h2>
+                <p className="text-gray-500">No hay servicios disponibles en este momento.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="w-full mb-8">
+            <div className="flex items-center justify-between mb-2">
+                <h2 className="text-xl font-bold text-gray-900">{title}</h2>
+                <div className="flex gap-2">
+                    <button
+                        onClick={() => scrollBy("left")}
+                        className="p-2 rounded-full bg-gray-200 hover:bg-gray-300 transition"
+                        aria-label="Scroll left"
+                    >
+                        <ChevronLeftIcon />
+                    </button>
+                    <button
+                        onClick={() => scrollBy("right")}
+                        className="p-2 rounded-full bg-gray-200 hover:bg-gray-300 transition"
+                        aria-label="Scroll right"
+                    >
+                        <ChevronRightIcon />
+                    </button>
+                </div>
+            </div>
+            <div
+                ref={scrollRef}
+                className="flex gap-4 overflow-x-auto scrollbar-hide pb-2"
+                style={{ scrollBehavior: "smooth" }}
+            >
+                {services.map((service) => (
+                    <div key={service.id} className="min-w-[320px]">
+                        <ServiceCard service={service} />
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/Explore.jsx
+++ b/frontend/src/pages/Explore.jsx
@@ -1,14 +1,83 @@
 // src/pages/Explore.jsx
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import { useNavigate } from "react-router-dom";
 import { pb } from "@/lib/pocketbase.js";
 import SearchBar from "../components/explore/searchbar";
 import CategoriesCarousel from "../components/explore/CategoriesCarousel";
 
+import ServiceCard from "../components/explore/ServiceCard";
+import ServicesCarousel from "../components/explore/ServicesCarousel";
+
+
 export default function Explore() {
   const [selectedCategory, setSelectedCategory] = useState(null);
 
+  // services. 
+  const [allServices, setAllServices] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  // services categories. 
+  const [ofertas_semanales, setOfertas_semanales] = useState([]);
+  const [servicios_populares, setServicios_populares] = useState([]);
+  const [empresas_populares, setEmpresas_populares] = useState([]);
+
   const navigate = useNavigate();
+
+  // use effect for services. 
+  useEffect(() => {
+    const loadAllServices = async () => {
+      try {
+        setLoading(true);
+        console.log("Iniciando carga de servicios...");
+        const services = await pb.collection("services").getFullList(500, {
+          sort: "-created",
+        });
+
+        setAllServices(services);
+        console.log(`✅ Cargados ${services.length} servicios.`);
+        console.log(services);
+
+        if (services.length > 0) {
+          console.log("🔍 Primer servicio:", services[0]);
+          console.log("🏷️ Campos disponibles:", Object.keys(services[0]));
+        }
+
+        // Cargar categorías específicas
+        // randomiza de allServices hacia ofertas_semanales, servicios_populares, empresas_populares. 
+        // que vaya el mismo numero a cada una. haz el calculo tomando la longitud de allServices.
+
+        // Mezclar los servicios y repartirlos en tres categorías iguales
+        const shuffleArray = (array) => {
+          return [...array].sort(() => Math.random() - 0.5); // copia para no mutar
+        };
+
+        const shuffledServices = shuffleArray(services);
+        const numServices = Math.floor(shuffledServices.length / 3);
+
+        const ofertas = shuffledServices.slice(0, numServices);
+        const populares = shuffledServices.slice(numServices, numServices * 2);
+        const empresas = shuffledServices.slice(numServices * 2, numServices * 3);
+
+        setOfertas_semanales(ofertas);
+        setServicios_populares(populares);
+        setEmpresas_populares(empresas);
+
+        console.log("Ofertas Semanales:", ofertas);
+        console.log("Servicios Populares:", populares);
+        console.log("Empresas Populares:", empresas);
+
+      } catch (e) {
+        console.error("❌ Error cargando servicios:", e);
+        alert("Error cargando servicios. Revisa consola.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadAllServices();
+  }, []);
+
+
+
 
   const handleSelectCategory = async (cat) => {
   try {
@@ -93,6 +162,24 @@ export default function Explore() {
           ? "Mostrando resultados para el rubro seleccionado."
           : "Selecciona un rubro para explorar servicios disponibles."}
       </p>
+
+      {/* Carruseles de servicios */}
+      <ServicesCarousel
+        title="Ofertas Semanales"
+        services={ofertas_semanales}
+        loading={loading}
+      />
+      <ServicesCarousel
+        title="Servicios Populares"
+        services={servicios_populares}
+        loading={loading}
+      />
+      <ServicesCarousel
+        title="Empresas Populares"
+        services={empresas_populares}
+        loading={loading}
+      />
+
     </div>
   );
 }


### PR DESCRIPTION
Introduces ServiceCard and ServicesCarousel components for displaying services in carousels on the Explore page. Fetches services from PocketBase, shuffles and distributes them into 'Ofertas Semanales', 'Servicios Populares', and 'Empresas Populares' carousels, and displays them with loading and empty states.